### PR TITLE
update fc, cleanup 2 C++, allow missmatched submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,34 @@ if(ENABLE_COVERAGE_TESTING)
     SET(CMAKE_CXX_FLAGS "--coverage ${CMAKE_CXX_FLAGS}")
 endif()
 
+add_flag_append(CMAKE_CXX_FLAGS "-fstack-protector")
+add_flag_append(CMAKE_CXX_FLAGS "-DBOOST_BIND_GLOBAL_PLACEHOLDERS") # to quiet the warnings (seen on Ubuntu 24.04 for example) about default _1 globals of boost (default to old behaviour of boost, this is what the code base expects)
+
+
+# -----------------------------------------------
+
+message(NOTICE "-----------------------------------------------")
+# Convert build type to uppercase - to check variable below
+string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
+
+# final flags considering the build type
+set(FINAL_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UPPER}}")
+set(FINAL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}}")
+
+# Print the used flags
+message(NOTICE "### CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+
+message(NOTICE "... CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+message(NOTICE "... CMAKE_C_FLAGS_${BUILD_TYPE_UPPER}: ${CMAKE_C_FLAGS_${BUILD_TYPE_UPPER}}")
+message(NOTICE "### FINAL_C_FLAGS: ${FINAL_C_FLAGS}")
+
+message(NOTICE "... CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+message(NOTICE "... CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}: ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}}")
+message(NOTICE "### FINAL_CXX_FLAGS: ${FINAL_CXX_FLAGS}")
+message(NOTICE "-----------------------------------------------")
+
+# -----------------------------------------------
+
 add_subdirectory( libraries )
 add_subdirectory( programs )
 add_subdirectory( tests )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,6 @@ if(ENABLE_COVERAGE_TESTING)
     SET(CMAKE_CXX_FLAGS "--coverage ${CMAKE_CXX_FLAGS}")
 endif()
 
-add_flag_append(CMAKE_CXX_FLAGS "-fstack-protector")
 add_flag_append(CMAKE_CXX_FLAGS "-DBOOST_BIND_GLOBAL_PLACEHOLDERS") # to quiet the warnings (seen on Ubuntu 24.04 for example) about default _1 globals of boost (default to old behaviour of boost, this is what the code base expects)
 
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "This is the script for Developer of application, to build it"
 set -x
-time cmake  -DCMAKE_C_COMPILER_LAUNCHER=ccache  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache   .    && time make -j 8
+time cmake  -DCMAKE_C_COMPILER_LAUNCHER=ccache  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMANUAL_SUBMODULES=1  .    && time make -j 8


### PR DESCRIPTION
- dev.sh: ALLOW NOW to just build even if submodule version was changed - for developers that edit deps at same time
- compilation warning here (boost bind)
- compilation warning in FC (template in safeint)
- also show final flags in CMake