### PR TITLE
support Clang20 ubuntu 25 04 by fixing missing-template-arg-list-after-template-kw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,10 @@ add_compiler_flag_if_available("-Wshift-negative-value")
 add_compiler_flag_if_available("-Wtype-limits")
 add_compiler_flag_if_available("-Wunused-but-set-parameter")
 
+# libraries/protocol/custom_authorities/safe_compare.hpp see EXP_TEMPLATE_DISAMBIG
+# (despite this setting, some new compilers will hard abort anyway, so we fix the C++ code too, in that file)
+add_compiler_flag_if_available("-Wno-error=missing-template-arg-list-after-template-kw")
+
 if( WIN32 )
 
     message( STATUS "Configuring BitShares on WIN32")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ add_compiler_flag_if_available("-Wunused-but-set-parameter")
 
 # libraries/protocol/custom_authorities/safe_compare.hpp see EXP_TEMPLATE_DISAMBIG
 # (despite this setting, some new compilers will hard abort anyway, so we fix the C++ code too, in that file)
+# see i.e. https://github.com/llvm/llvm-project/issues/94194
 add_compiler_flag_if_available("-Wno-error=missing-template-arg-list-after-template-kw")
 
 if( WIN32 )

--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 echo "This is the script for Developer of application, to build it"
 jobs=$(./make-get-jobs 1024 110 0 256)
+
+jobs_arg_forced=false
+for arg in "$@"; do
+  if [[ $arg == --jobs=* ]]; then
+    jobs="${arg#--jobs=}"
+    jobs_arg_forced=true
+  fi
+done
+if $jobs_arg_forced; then
+  echo "Jobs was forced via argument: $jobs"
+fi
+
 echo "using $jobs jobs"
 set -x
 time cmake -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_C_COMPILER_LAUNCHER=ccache  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMANUAL_SUBMODULES=1  .    && printf "\n\n\nmake with $jobs jobs.\n\n" && time make -j ${jobs}

--- a/dev.sh
+++ b/dev.sh
@@ -13,6 +13,10 @@ if $jobs_arg_forced; then
   echo "Jobs was forced via argument: $jobs"
 fi
 
-echo "using $jobs jobs"
+echo "======================================================================"
+echo "Using $jobs job(s), using CXX=$CXX, CC=$CC."
 set -x
 time cmake -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_C_COMPILER_LAUNCHER=ccache  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMANUAL_SUBMODULES=1  .    && printf "\n\n\nmake with $jobs jobs.\n\n" && time make -j ${jobs}
+echo "======================================================================"
+echo "Using $jobs job(s), using CXX=$CXX, CC=$CC."
+echo "Finished"

--- a/libraries/protocol/custom_authorities/safe_compare.hpp
+++ b/libraries/protocol/custom_authorities/safe_compare.hpp
@@ -19,6 +19,32 @@ namespace boost {
 namespace safe_numerics {
 namespace safe_compare {
 
+// some (broken) compilers needed extra word "template" in some c++ expressions
+// other ones allow it but do not need it (ignore it)
+// while most new have it as diagnostic, of them some can not be ignored
+// the correct C++ is to define this macro to nothing "", so to not use the extra word "template" in this places
+#if defined(_MSC_VER)
+  // MSVC historically permissive — keep the token for compatibility
+  #define EXP_TEMPLATE_DISAMBIG template
+#elif defined(__clang__)
+  // Treat Clang <= 19 (especially 18) as "old"
+  #if __clang_major__ <= 19
+    #define EXP_TEMPLATE_DISAMBIG template
+  #else
+    #define EXP_TEMPLATE_DISAMBIG
+  #endif
+#elif defined(__GNUC__)
+  // Treat GCC <= 14 (especially 13) as "old"
+  #if __GNUC__ <= 13
+    #define EXP_TEMPLATE_DISAMBIG template
+  #else
+    #define EXP_TEMPLATE_DISAMBIG
+  #endif
+#else
+  // for unknown compilers:
+  #define EXP_TEMPLATE_DISAMBIG
+#endif
+
 ////////////////////////////////////////////////////
 // safe comparison on primitive integral types
 namespace safe_compare_detail {
@@ -81,7 +107,7 @@ constexpr less_than(const T & lhs, const U & rhs) {
     return safe_compare_detail::less_than<
         std::is_signed<T>::value,
         std::is_signed<U>::value
-    >::template invoke(lhs, rhs);
+    >::EXP_TEMPLATE_DISAMBIG invoke(lhs, rhs);
 }
 
 template<class T, class U>
@@ -161,7 +187,7 @@ constexpr equal(const T & lhs, const U & rhs) {
     return safe_compare_detail::equal<
         std::numeric_limits<T>::is_signed,
         std::numeric_limits<U>::is_signed
-    >::template invoke(lhs, rhs);
+    >::EXP_TEMPLATE_DISAMBIG invoke(lhs, rhs);
 }
 
 template<class T, class U>

--- a/libraries/protocol/custom_authorities/safe_compare.hpp
+++ b/libraries/protocol/custom_authorities/safe_compare.hpp
@@ -19,13 +19,15 @@ namespace boost {
 namespace safe_numerics {
 namespace safe_compare {
 
-// some (broken) compilers needed extra word "template" in some c++ expressions
-// other ones allow it but do not need it (ignore it)
-// while most new have it as diagnostic, of them some can not be ignored
+// 1) some (broken, old MSVC?) compilers needed extra word "template" in some c++ expressions
+// 2) other compilers do not need it, but allow it silently or with mild warning
+// 3) others enforce correct C++ language, and the extra word will break compilation (new clang20 i.e.)
 // the correct C++ is to define this macro to nothing "", so to not use the extra word "template" in this places
+// here we enable the extra word if we think compiler needs it, or if it was done that way on that compilers before in this project
 #if defined(_MSC_VER)
   // MSVC historically permissive — keep the token for compatibility
   #define EXP_TEMPLATE_DISAMBIG template
+	// TODO one day on new MSVC we can also drop it
 #elif defined(__clang__)
   // Treat Clang <= 19 (especially 18) as "old"
   #if __clang_major__ <= 19
@@ -207,5 +209,7 @@ constexpr bool not_equal(const T & lhs, const U & rhs) {
 } // safe_compare
 } // safe_numerics
 } // boost
+
+#undef EXP_TEMPLATE_DISAMBIG
 
 #endif // BOOST_NUMERIC_SAFE_COMPARE_HPP

--- a/libraries/protocol/custom_authorities/safe_compare.hpp
+++ b/libraries/protocol/custom_authorities/safe_compare.hpp
@@ -19,6 +19,7 @@ namespace boost {
 namespace safe_numerics {
 namespace safe_compare {
 
+// related to: missing-template-arg-list-after-template-kw
 // 1) some (broken, old MSVC?) compilers needed extra word "template" in some c++ expressions
 // 2) other compilers do not need it, but allow it silently or with mild warning
 // 3) others enforce correct C++ language, and the extra word will break compilation (new clang20 i.e.)


### PR DESCRIPTION
similar problem to https://github.com/llvm/llvm-project/issues/94194
known as: missing-template-arg-list-after-template-kw

seems ok
fix also includes in lib FC submod

seems to build (ubuntu 25.04)? 
- [x] g++-14
- [x] clang++-18
- [x] clang++-20